### PR TITLE
Use BuildTypeId instead of BuildId

### DIFF
--- a/server/src/main/buildServerResources/feature.jsp
+++ b/server/src/main/buildServerResources/feature.jsp
@@ -52,6 +52,14 @@
 </l:settingsGroup>
 <l:settingsGroup title="Other">
 <tr>
+  <th>Only Latest:</th>
+  <td>
+    <props:checkboxProperty name="${keys.onlyLatestKey}" />
+    <span class="error" id="error_${keys.onlyLatestKey}"></span>
+    <span class="smallNote">Only show latest build status for each commit.</span>
+  </td>
+</tr>
+<tr>
   <th>Ignore VCS Roots:</th>
   <td>
     <props:textProperty name="${keys.VCSIgnoreKey}" className="longField"/>

--- a/server/src/main/java/mendhak/teamcity/stash/ChangeStatusUpdater.java
+++ b/server/src/main/java/mendhak/teamcity/stash/ChangeStatusUpdater.java
@@ -166,7 +166,10 @@ public class ChangeStatusUpdater
                                 feature.getParameters().get(keyNames.getUserNameKey()),
                                 feature.getParameters().get(keyNames.getPasswordKey()));
 
-                        client.SendBuildStatus(status, build.getBuildTypeId(),
+                        boolean onlyShowLatestBuild =
+                                Boolean.valueOf(feature.getParameters().get(keyNames.getOnlyLatestKey()));
+                        client.SendBuildStatus(status,
+                                onlyShowLatestBuild ? build.getBuildTypeId() : String.valueOf(build.getBuildId()),
                                 getBuildDisplayName(build), myWeb.getViewResultsUrl(build),
                                 getBuildDisplayDescription(build), hash);
 

--- a/server/src/main/java/mendhak/teamcity/stash/ui/StashServerKeyNames.java
+++ b/server/src/main/java/mendhak/teamcity/stash/ui/StashServerKeyNames.java
@@ -37,6 +37,11 @@ public class StashServerKeyNames
         return Constants.SECURE_PROPERTY_PREFIX + "stash_username";
     }
 
+    public String getOnlyLatestKey()
+    {
+        return "stash_only_latest";
+    }
+
     public String getVCSIgnoreKey()
     {
         return "stash_vcsignorecsv";


### PR DESCRIPTION
See https://jira.atlassian.com/browse/STASH-3219

If TeamCity build is canceled and another one is started, then Stash will show two builds, and first one is Failed. It can't be overwriten by Success build reexecution.

Also if build failed on of external problem it never be replaced by Success run for the same build on the same commit. Because `BuildId` is always different.
